### PR TITLE
Bashinterna ...

### DIFF
--- a/calculations/script4.sh
+++ b/calculations/script4.sh
@@ -13,7 +13,7 @@ betrag1=100
 betrag2=50
 
 # ausrechnen des Gesamtbetrags
-summe=`expr $betrag1 + $betrag2`
+summe=$(( $betrag1 + $betrag2 ))
 
 # ausgeben der Summe
 echo "Summe: $betrag1 + $betrag2 = $summe"

--- a/calculations/script5.sh
+++ b/calculations/script5.sh
@@ -24,7 +24,7 @@ betrag2=$2
 betrag3=$3
 
 # Addition (komplexe Berechnung ...)
-summe=`expr $betrag1 + $betrag2 + $betrag3`
+summe=$(( $betrag1 + $betrag2 + $betrag3 ))
 
 # Ausgabe der Gesamtsumme
 echo "Gesamtsumme: $betrag1 + $betrag2 + $betrag3 = $summe"

--- a/calculations/script6.sh
+++ b/calculations/script6.sh
@@ -21,14 +21,14 @@ echo "Übermittelte Parameter: $*"
 summe=0
 
 # Prüfen, ob überhaupt Parameter da sind
-if [ $# -gt 0 ]
+if [[ $# -gt 0 ]]
 then
 
   # Schleife zur Ausgabe der Parameter
   for i in $*
     do
     # mach was und addiere zur Gesamtsumme
-    summe=`expr $summe + $i`
+	summe=$(( $summe + $i ))
     echo "Parameter: $i"
     done
 

--- a/xargs/xargs.sh
+++ b/xargs/xargs.sh
@@ -9,7 +9,7 @@
 # -----------------------------------------------------------
 
 # using a for loop
-for filename in `find . -name "*.sh"`
+for filename in $(find . -name "*.sh")
 do
 	ls -lah $filename
 done
@@ -19,4 +19,4 @@ find . -name "*.sh" -print | xargs ls -lah
 
 # alternative writing: using a specific find argument
 # order: find where-to-look criteria what-to-do
-find . -name "*.sh" -exec ls -lah '{}' \;
+find . -name "*.sh" -exec ls -lah '{}' \+


### PR DESCRIPTION
Ich habe bei dem find noch eine Beschreibung vergessen.

Das Semikolon ";" sorgt dafür, dass für jede gefundene Datei ein Subprozess gestartet wird. Das Pluszeichen "+" macht so viele Ergebnisse in eine Kommandozeile, wie passen.

Aus 

```
find datei -exec echo '{}' \;
```

wird

```
echo datei1
echo datei2
echo datei3
```

aus 

```
find datei -exec echo '{}' \+
```

wird

```
echo datei1 datei2 datei3
```

Im vorliegenden Fall ist das zweite Verhalten wünschenswert.
